### PR TITLE
Dev server failed to start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,5 @@ RUN yarn install
 
 COPY . ./
 
-CMD ["yarn"]
+CMD ["yarn", "dev"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN apk add -U --no-cache \
       bash \
       git \
       curl
+RUN mkdir -p /app/api-graphql
 
 WORKDIR /app/api-graphql
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,16 @@
-FROM node:7.9-alpine
+FROM node:fermium-alpine
 
 RUN apk add -U --no-cache \
       bash \
       git \
-      curl \
-      && \
-    mkdir -p /app/api-graphql
+      curl
 
 WORKDIR /app/api-graphql
 
 # Copy the package.json as well and install all packages.
 # This is a separate step so the dependencies
 # will be cached unless changes the file are made.
-COPY package.json yarn.lock ./
+COPY yarn.lock package.json ./
 RUN yarn install
 
 COPY . ./

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -4,7 +4,6 @@ RUN apk add -U --no-cache \
       bash \
       git \
       curl
-
 RUN mkdir -p /app/api-graphql
 
 WORKDIR /app/api-graphql
@@ -12,7 +11,7 @@ WORKDIR /app/api-graphql
 # Copy the package.json as well and install all packages.
 # This is a separate step so the dependencies
 # will be cached unless changes the file are made.
-COPY package.json yarn.lock ./
+COPY yarn.lock package.json ./
 RUN yarn install
 
 COPY . ./

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -18,5 +18,5 @@ COPY . ./
 
 RUN yarn run build
 
-CMD ["yarn"]
+CMD ["yarn", "start"]
 

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -1,11 +1,11 @@
-FROM node:7.9-alpine
+FROM node:fermium-alpine
 
 RUN apk add -U --no-cache \
       bash \
       git \
-      curl \
-      && \
-    mkdir -p /app/api-graphql
+      curl
+
+RUN mkdir -p /app/api-graphql
 
 WORKDIR /app/api-graphql
 
@@ -13,7 +13,6 @@ WORKDIR /app/api-graphql
 # This is a separate step so the dependencies
 # will be cached unless changes the file are made.
 COPY package.json yarn.lock ./
-
 RUN yarn install
 
 COPY . ./

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,15 +11,15 @@ services:
       - ./src:/app/api-graphql/src
     ports:
       - "3000:3000"
-    command: yarn dev 
 
   realworld-graphql:
     extends: common-app
 
   realworld-graphql-prod:
     extends: common-app
+    environment:
+      - NODE_ENV=production
     build:
       context: ./
       dockerfile: Dockerfile.production
-    command: yarn start
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - ./src:/app/api-graphql/src
     ports:
       - "3000:3000"
+    command: yarn dev 
 
   realworld-graphql:
     extends: common-app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,13 +4,11 @@ services:
   # App
   common-app:
     build: ./
-    command: yarn dev
     #env_file: .env.dev
     environment:
       - NODE_ENV=development
     volumes:
-      - ./:/app/api-graphql
-
+      - ./src:/app/api-graphql/src
     ports:
       - "3000:3000"
 

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ This repo is **under development** yet! **Contributors** are very welcomed!
 # Getting started
 
 ```bash
-$ git clone git@github.com:thebergamo/realworld-graphql.git
+$ git clone https://github.com/thebergamo/realworld-graphql.git
 
 $ cd realworld-graphql
 


### PR DESCRIPTION
This PR addresses the following issues

- In README file, git clone was via ssh which is switched to https
- Dev server was failing to start because of node_modules
- node alpine base image was using node v7 which I have updated to node fermium (v14)
- NODE_ENV=development was passed in prod build as well which led to opening graphiql endpoint in prod as well
- Moved command parameter from docker-compose file for every service to CMD of Dockerfile